### PR TITLE
Retrieves dependencies via Mix in installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 program_flow.umd
 .DS_Store
 
+# Executable
+mati

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+echo "Retrieving dependencies"
+mix deps.get
+
 echo "Generating executable"
 mix escript.build
 


### PR DESCRIPTION
Simply adds the `mix deps.get` to the installation script to make it more plug&play.

Also ignores the generated escript.